### PR TITLE
refactor: Заменен вызов deprecated метода в примере

### DIFF
--- a/pages/framework/events.md
+++ b/pages/framework/events.md
@@ -72,7 +72,7 @@ $event->send();
 
 if ($event->getResults()) {
     foreach ($event->getResults() as $eventResult) {
-        if ($eventResult->getResultType() == \Bitrix\Main\EventResult::SUCCESS) {
+        if ($eventResult->getType() == \Bitrix\Main\EventResult::SUCCESS) {
             $arMacros["PRODUCTS"] = $eventResult->getParameters();
         }
     }


### PR DESCRIPTION
В примере по  событиям был вызов метода, который объявлен deprecated