### PR TITLE
Исправление устаревшего пространства имен

### DIFF
--- a/pages/orm/objects.md
+++ b/pages/orm/objects.md
@@ -266,7 +266,7 @@ $values = $book->collectValues(
 ```php
 $author = \Bitrix\Main\Test\Typography\AuthorTable::query()
     ->registerRuntimeField(
-        new \Bitrix\Main\Entity\ExpressionField(
+        new \Bitrix\Main\ORM\Fields\ExpressionField(
             'FULL_NAME', 'CONCAT(%s, " ", %s)', ['NAME', 'LAST_NAME']
         )
     )
@@ -714,7 +714,7 @@ $author['NAME'] = 'New name';
 ```php
 $author = \Bitrix\Main\Test\Typography\AuthorTable::query()
     ->registerRuntimeField(
-        new \Bitrix\Main\Entity\ExpressionField('FULL_NAME', 'CONCAT(%s, " ", %s)', ['NAME', 'LAST_NAME'])
+        new \Bitrix\Main\ORM\Fields\ExpressionField('FULL_NAME', 'CONCAT(%s, " ", %s)', ['NAME', 'LAST_NAME'])
     )
     ->addSelect('ID')
     ->addSelect('FULL_NAME')


### PR DESCRIPTION
В примерах фигурирует устаревший путь \Bitrix\Main\Entity\ExpressionField . Патч заменяет на \Bitrix\Main\ORM\Fields\ExpressionField